### PR TITLE
Fix JSON serializer settings and update packages

### DIFF
--- a/OkonkwoOandaV20/OkonkwoOandaV20/Framework/Utilities.cs
+++ b/OkonkwoOandaV20/OkonkwoOandaV20/Framework/Utilities.cs
@@ -38,15 +38,6 @@ namespace OkonkwoOandaV20.Framework
          return queryString.ToString().TrimEnd('&');
       }
 
-      public static TokenCredential GetAzureCredential(bool isLocalEnvironment = true)
-      {
-         var credentialOptions = new DefaultAzureCredentialOptions
-         {
-            ExcludeManagedIdentityCredential = isLocalEnvironment
-         };
-         return new DefaultAzureCredential(credentialOptions);
-      }
-
       internal static string ToDistinctCSV(this IEnumerable<string> list)
       {
          return string.Join(",", list.Distinct());

--- a/OkonkwoOandaV20/OkonkwoOandaV20/OkonkwoOandaV20.csproj
+++ b/OkonkwoOandaV20/OkonkwoOandaV20/OkonkwoOandaV20.csproj
@@ -33,78 +33,81 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Azure.Core, Version=1.54.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8, processorArchitecture=MSIL">
-      <HintPath>..\packages\Azure.Core.1.54.0\lib\net472\Azure.Core.dll</HintPath>
+    <Reference Include="Azure.Core, Version=1.62.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8, processorArchitecture=MSIL">
+      <HintPath>..\packages\Azure.Core.1.62.0\lib\net472\Azure.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=10.0.0.3, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Bcl.AsyncInterfaces.10.0.3\lib\net462\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
+    <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Bcl.AsyncInterfaces.10.0.11\lib\net462\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="Microsoft.Extensions.Configuration.Abstractions, Version=10.0.0.3, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Configuration.Abstractions.10.0.3\lib\net462\Microsoft.Extensions.Configuration.Abstractions.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Configuration.Abstractions, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Configuration.Abstractions.10.0.11\lib\net462\Microsoft.Extensions.Configuration.Abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=10.0.0.3, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.10.0.3\lib\net462\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.10.0.11\lib\net462\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Diagnostics.Abstractions, Version=10.0.0.3, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Diagnostics.Abstractions.10.0.3\lib\net462\Microsoft.Extensions.Diagnostics.Abstractions.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Diagnostics.Abstractions, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Diagnostics.Abstractions.10.0.11\lib\net462\Microsoft.Extensions.Diagnostics.Abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.FileProviders.Abstractions, Version=10.0.0.3, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.FileProviders.Abstractions.10.0.3\lib\net462\Microsoft.Extensions.FileProviders.Abstractions.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.FileProviders.Abstractions, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.FileProviders.Abstractions.10.0.11\lib\net462\Microsoft.Extensions.FileProviders.Abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Hosting.Abstractions, Version=10.0.0.3, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Hosting.Abstractions.10.0.3\lib\net462\Microsoft.Extensions.Hosting.Abstractions.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Hosting.Abstractions, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Hosting.Abstractions.10.0.11\lib\net462\Microsoft.Extensions.Hosting.Abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Logging.Abstractions, Version=10.0.0.3, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Logging.Abstractions.10.0.3\lib\net462\Microsoft.Extensions.Logging.Abstractions.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Logging.Abstractions, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Logging.Abstractions.10.0.11\lib\net462\Microsoft.Extensions.Logging.Abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Options, Version=10.0.0.3, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Options.10.0.3\lib\net462\Microsoft.Extensions.Options.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Options, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Options.10.0.11\lib\net462\Microsoft.Extensions.Options.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Primitives, Version=10.0.0.3, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Primitives.10.0.3\lib\net462\Microsoft.Extensions.Primitives.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Primitives, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Primitives.10.0.11\lib\net462\Microsoft.Extensions.Primitives.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Identity.Client, Version=4.83.1.0, Culture=neutral, PublicKeyToken=0a613f4dd989e8ae, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Identity.Client.4.83.1\lib\net472\Microsoft.Identity.Client.dll</HintPath>
+    <Reference Include="Microsoft.Identity.Client, Version=4.88.0.0, Culture=neutral, PublicKeyToken=0a613f4dd989e8ae, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Identity.Client.4.88.0\lib\net472\Microsoft.Identity.Client.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Identity.Client.Extensions.Msal, Version=4.83.1.0, Culture=neutral, PublicKeyToken=0a613f4dd989e8ae, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Identity.Client.Extensions.Msal.4.83.1\lib\netstandard2.0\Microsoft.Identity.Client.Extensions.Msal.dll</HintPath>
+    <Reference Include="Microsoft.Identity.Client.Extensions.Msal, Version=4.88.0.0, Culture=neutral, PublicKeyToken=0a613f4dd989e8ae, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Identity.Client.Extensions.Msal.4.88.0\lib\netstandard2.0\Microsoft.Identity.Client.Extensions.Msal.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.IdentityModel.Abstractions, Version=8.14.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.IdentityModel.Abstractions.8.14.0\lib\net472\Microsoft.IdentityModel.Abstractions.dll</HintPath>
+    <Reference Include="Microsoft.IdentityModel.Abstractions, Version=8.22.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.IdentityModel.Abstractions.8.22.0\lib\net472\Microsoft.IdentityModel.Abstractions.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.13.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\packages\Newtonsoft.Json.13.0.4\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Buffers, Version=4.0.5.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Buffers.4.6.1\lib\net462\System.Buffers.dll</HintPath>
     </Reference>
-    <Reference Include="System.ClientModel, Version=1.10.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.ClientModel.1.10.0\lib\netstandard2.0\System.ClientModel.dll</HintPath>
+    <Reference Include="System.ClientModel, Version=1.15.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.ClientModel.1.15.0\lib\netstandard2.0\System.ClientModel.dll</HintPath>
     </Reference>
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Diagnostics.DiagnosticSource, Version=10.0.0.3, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Diagnostics.DiagnosticSource.10.0.3\lib\net462\System.Diagnostics.DiagnosticSource.dll</HintPath>
+    <Reference Include="System.Diagnostics.DiagnosticSource, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Diagnostics.DiagnosticSource.10.0.11\lib\net462\System.Diagnostics.DiagnosticSource.dll</HintPath>
     </Reference>
     <Reference Include="System.Drawing" />
-    <Reference Include="System.Formats.Asn1, Version=8.0.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Formats.Asn1.8.0.1\lib\net462\System.Formats.Asn1.dll</HintPath>
+    <Reference Include="System.Formats.Asn1, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Formats.Asn1.10.0.11\lib\net462\System.Formats.Asn1.dll</HintPath>
     </Reference>
     <Reference Include="System.IdentityModel" />
     <Reference Include="System.IO.Compression" />
     <Reference Include="System.IO.FileSystem.AccessControl, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.IO.FileSystem.AccessControl.5.0.0\lib\net461\System.IO.FileSystem.AccessControl.dll</HintPath>
     </Reference>
-    <Reference Include="System.IO.Pipelines, Version=10.0.0.3, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.IO.Pipelines.10.0.3\lib\net462\System.IO.Pipelines.dll</HintPath>
+    <Reference Include="System.IO.Pipelines, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IO.Pipelines.10.0.11\lib\net462\System.IO.Pipelines.dll</HintPath>
     </Reference>
     <Reference Include="System.Memory, Version=4.0.5.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Memory.4.6.3\lib\net462\System.Memory.dll</HintPath>
     </Reference>
-    <Reference Include="System.Memory.Data, Version=10.0.0.3, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Memory.Data.10.0.3\lib\net462\System.Memory.Data.dll</HintPath>
+    <Reference Include="System.Memory.Data, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Memory.Data.10.0.11\lib\net462\System.Memory.Data.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Net.ServerSentEvents, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Net.ServerSentEvents.10.0.11\lib\net462\System.Net.ServerSentEvents.dll</HintPath>
     </Reference>
     <Reference Include="System.Numerics" />
     <Reference Include="System.Numerics.Vectors, Version=4.1.6.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
@@ -115,24 +118,25 @@
     </Reference>
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Security" />
-    <Reference Include="System.Security.AccessControl, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Security.AccessControl.5.0.0\lib\net461\System.Security.AccessControl.dll</HintPath>
+    <Reference Include="System.Security.AccessControl, Version=6.0.0.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.AccessControl.6.0.1\lib\net461\System.Security.AccessControl.dll</HintPath>
     </Reference>
-    <Reference Include="System.Security.Cryptography.ProtectedData, Version=4.0.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Security.Cryptography.ProtectedData.4.5.0\lib\net461\System.Security.Cryptography.ProtectedData.dll</HintPath>
+    <Reference Include="System.Security.Cryptography.ProtectedData, Version=10.0.0.11, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Cryptography.ProtectedData.10.0.11\lib\net462\System.Security.Cryptography.ProtectedData.dll</HintPath>
     </Reference>
     <Reference Include="System.Security.Principal.Windows, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Security.Principal.Windows.5.0.0\lib\net461\System.Security.Principal.Windows.dll</HintPath>
     </Reference>
-    <Reference Include="System.Text.Encodings.Web, Version=10.0.0.3, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Text.Encodings.Web.10.0.3\lib\net462\System.Text.Encodings.Web.dll</HintPath>
+    <Reference Include="System.Text.Encodings.Web, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Text.Encodings.Web.10.0.11\lib\net462\System.Text.Encodings.Web.dll</HintPath>
     </Reference>
-    <Reference Include="System.Text.Json, Version=10.0.0.3, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Text.Json.10.0.3\lib\net462\System.Text.Json.dll</HintPath>
+    <Reference Include="System.Text.Json, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Text.Json.10.0.11\lib\net462\System.Text.Json.dll</HintPath>
     </Reference>
     <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.4.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Threading.Tasks.Extensions.4.6.3\lib\net462\System.Threading.Tasks.Extensions.dll</HintPath>
     </Reference>
+    <Reference Include="System.ValueTuple" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
@@ -237,7 +241,7 @@
     <Compile Include="TradeLibrary\Pricing\UnitsAvailable.cs" />
     <Compile Include="TradeLibrary\Pricing\UnitsAvailableDetails.cs" />
     <Compile Include="TradeLibrary\Rest20.cs" />
-    <Compile Include="TradeLibrary\REST\ApiParameters.cs" />
+    <Compile Include="TradeLibrary\REST\ClientParameters.cs" />
     <Compile Include="TradeLibrary\REST\Credentials.cs" />
     <Compile Include="TradeLibrary\REST\HttpParameters.cs" />
     <Compile Include="TradeLibrary\REST\Primitives.cs" />
@@ -314,12 +318,12 @@
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\System.ValueTuple.4.6.1\build\net471\System.ValueTuple.targets" Condition="Exists('..\packages\System.ValueTuple.4.6.1\build\net471\System.ValueTuple.targets')" />
+  <Import Project="..\packages\System.ValueTuple.4.6.2\build\net471\System.ValueTuple.targets" Condition="Exists('..\packages\System.ValueTuple.4.6.2\build\net471\System.ValueTuple.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\System.ValueTuple.4.6.1\build\net471\System.ValueTuple.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\System.ValueTuple.4.6.1\build\net471\System.ValueTuple.targets'))" />
+    <Error Condition="!Exists('..\packages\System.ValueTuple.4.6.2\build\net471\System.ValueTuple.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\System.ValueTuple.4.6.2\build\net471\System.ValueTuple.targets'))" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/OkonkwoOandaV20/OkonkwoOandaV20/TradeLibrary/Account/REST/GetAccount.cs
+++ b/OkonkwoOandaV20/OkonkwoOandaV20/TradeLibrary/Account/REST/GetAccount.cs
@@ -31,7 +31,7 @@ namespace OkonkwoOandaV20.TradeLibrary.REST
       }
    }
 
-   public class AccountParameters : ApiParameters
+   public class AccountParameters : ClientParameters
    {
       /// <summary>
       /// Account Identifier [required]

--- a/OkonkwoOandaV20/OkonkwoOandaV20/TradeLibrary/Instrument/REST/GetInstrumentCandles.cs
+++ b/OkonkwoOandaV20/OkonkwoOandaV20/TradeLibrary/Instrument/REST/GetInstrumentCandles.cs
@@ -115,7 +115,7 @@ namespace OkonkwoOandaV20.TradeLibrary.REST
          public string weeklyAlignment { get; set; }
       }
 
-      public class InstrumentParameters : ApiParameters
+      public class InstrumentParameters : ClientParameters
       {
          /// <summary>
          /// Name of the instrument

--- a/OkonkwoOandaV20/OkonkwoOandaV20/TradeLibrary/Order/REST/GetOrder.cs
+++ b/OkonkwoOandaV20/OkonkwoOandaV20/TradeLibrary/Order/REST/GetOrder.cs
@@ -33,7 +33,7 @@ namespace OkonkwoOandaV20.TradeLibrary.REST
       }
    }
 
-   public class OrderParameters : ApiParameters
+   public class OrderParameters : ClientParameters
    {
       /// <summary>
       /// Account Identifier [required]

--- a/OkonkwoOandaV20/OkonkwoOandaV20/TradeLibrary/Order/REST/GetOrders.cs
+++ b/OkonkwoOandaV20/OkonkwoOandaV20/TradeLibrary/Order/REST/GetOrders.cs
@@ -37,7 +37,7 @@ namespace OkonkwoOandaV20.TradeLibrary.REST
          return response;
       }
 
-      public class OrdersParameters : ApiParameters
+      public class OrdersParameters : ClientParameters
       {
          /// <summary>
          /// Account Identifier [required]

--- a/OkonkwoOandaV20/OkonkwoOandaV20/TradeLibrary/Order/REST/GetPendingOrders.cs
+++ b/OkonkwoOandaV20/OkonkwoOandaV20/TradeLibrary/Order/REST/GetPendingOrders.cs
@@ -34,7 +34,7 @@ namespace OkonkwoOandaV20.TradeLibrary.REST
       }
    }
 
-   public class PendingOrdersParameters : ApiParameters
+   public class PendingOrdersParameters : ClientParameters
    {
       /// <summary>
       /// Account Identifier [required]

--- a/OkonkwoOandaV20/OkonkwoOandaV20/TradeLibrary/Order/REST/PostOrder.cs
+++ b/OkonkwoOandaV20/OkonkwoOandaV20/TradeLibrary/Order/REST/PostOrder.cs
@@ -34,7 +34,7 @@ namespace OkonkwoOandaV20.TradeLibrary.REST
       }
    }
 
-   public class PostOrderParameters : ApiParameters
+   public class PostOrderParameters : ClientParameters
    {
       /// <summary>
       /// Account Identifier [required]

--- a/OkonkwoOandaV20/OkonkwoOandaV20/TradeLibrary/Order/REST/PutOrderCancel.cs
+++ b/OkonkwoOandaV20/OkonkwoOandaV20/TradeLibrary/Order/REST/PutOrderCancel.cs
@@ -31,7 +31,7 @@ namespace OkonkwoOandaV20.TradeLibrary.REST
       }
    }
 
-   public class OrderCancelParameters : ApiParameters
+   public class OrderCancelParameters : ClientParameters
    {
       /// <summary>
       /// Account Identifier [required]

--- a/OkonkwoOandaV20/OkonkwoOandaV20/TradeLibrary/Order/REST/PutOrderClientExtensions.cs
+++ b/OkonkwoOandaV20/OkonkwoOandaV20/TradeLibrary/Order/REST/PutOrderClientExtensions.cs
@@ -32,7 +32,7 @@ namespace OkonkwoOandaV20.TradeLibrary.REST
          return response;
       }
 
-      public class OrderClientExtensionsParameters : ApiParameters
+      public class OrderClientExtensionsParameters : ClientParameters
       {
          /// <summary>
          /// Account Identifier [required]

--- a/OkonkwoOandaV20/OkonkwoOandaV20/TradeLibrary/Order/REST/PutOrderReplace.cs
+++ b/OkonkwoOandaV20/OkonkwoOandaV20/TradeLibrary/Order/REST/PutOrderReplace.cs
@@ -38,7 +38,7 @@ namespace OkonkwoOandaV20.TradeLibrary.REST
       }
    }
 
-   public class OrderReplaceParameters : ApiParameters
+   public class OrderReplaceParameters : ClientParameters
    {
       /// <summary>
       /// Account Identifier [required]

--- a/OkonkwoOandaV20/OkonkwoOandaV20/TradeLibrary/Position/REST/GetOpenPositions.cs
+++ b/OkonkwoOandaV20/OkonkwoOandaV20/TradeLibrary/Position/REST/GetOpenPositions.cs
@@ -33,7 +33,7 @@ namespace OkonkwoOandaV20.TradeLibrary.REST
       }
    }
 
-   public class OpenPositionsParameters : ApiParameters
+   public class OpenPositionsParameters : ClientParameters
    {
       /// <summary>
       /// Account Identifier [required]

--- a/OkonkwoOandaV20/OkonkwoOandaV20/TradeLibrary/Position/REST/GetPosition.cs
+++ b/OkonkwoOandaV20/OkonkwoOandaV20/TradeLibrary/Position/REST/GetPosition.cs
@@ -31,7 +31,7 @@ namespace OkonkwoOandaV20.TradeLibrary.REST
       }
    }
 
-   public class PositionParameters : ApiParameters
+   public class PositionParameters : ClientParameters
    {
       /// <summary>
       /// Account Identifier [required]

--- a/OkonkwoOandaV20/OkonkwoOandaV20/TradeLibrary/Position/REST/GetPositions.cs
+++ b/OkonkwoOandaV20/OkonkwoOandaV20/TradeLibrary/Position/REST/GetPositions.cs
@@ -30,7 +30,7 @@ namespace OkonkwoOandaV20.TradeLibrary.REST
       }
    }
 
-   public class PositionsParameters : ApiParameters
+   public class PositionsParameters : ClientParameters
    {
       /// <summary>
       /// Account Identifier [required]

--- a/OkonkwoOandaV20/OkonkwoOandaV20/TradeLibrary/Position/REST/PutPositionClose.cs
+++ b/OkonkwoOandaV20/OkonkwoOandaV20/TradeLibrary/Position/REST/PutPositionClose.cs
@@ -31,7 +31,7 @@ namespace OkonkwoOandaV20.TradeLibrary.REST
          return response;
       }
 
-      public class PositionCloseParameters : ApiParameters
+      public class PositionCloseParameters : ClientParameters
       {
          /// <summary>
          /// Account Identifier [required]

--- a/OkonkwoOandaV20/OkonkwoOandaV20/TradeLibrary/Pricing/REST/GetPricing.cs
+++ b/OkonkwoOandaV20/OkonkwoOandaV20/TradeLibrary/Pricing/REST/GetPricing.cs
@@ -34,7 +34,7 @@ namespace OkonkwoOandaV20.TradeLibrary.REST
          return response;
       }
 
-      public class PricingParameters : ApiParameters
+      public class PricingParameters : ClientParameters
       {
          /// <summary>
          /// Account Identifier [required]

--- a/OkonkwoOandaV20/OkonkwoOandaV20/TradeLibrary/Pricing/REST/GetPricingStream.cs
+++ b/OkonkwoOandaV20/OkonkwoOandaV20/TradeLibrary/Pricing/REST/GetPricingStream.cs
@@ -31,7 +31,7 @@ namespace OkonkwoOandaV20.TradeLibrary.REST
          return await MakeStreamRequestAsync<PricingStreamErrorResponse>(requestParams, cancellation);
       }
 
-      public class PricingStreamParameters : ApiParameters
+      public class PricingStreamParameters : ClientParameters
       {
          public PricingStreamParameters() { snapshot = true; }
 

--- a/OkonkwoOandaV20/OkonkwoOandaV20/TradeLibrary/REST/ClientParameters.cs
+++ b/OkonkwoOandaV20/OkonkwoOandaV20/TradeLibrary/REST/ClientParameters.cs
@@ -5,7 +5,7 @@ namespace OkonkwoOandaV20.TradeLibrary.REST
    /// <summary>
    /// Base class for API parameters, providing a common structure for all parameter classes used in API requests.
    /// </summary>
-   public abstract class ApiParameters
+   public abstract class ClientParameters
    {
       // base class
       // can be used to introduce shared properties and behavior as needed
@@ -30,7 +30,7 @@ namespace OkonkwoOandaV20.TradeLibrary.REST
    /// <summary>
    /// Class for stream API parameters, providing a common structure for all parameter classes used in API requests.
    /// </summary>
-   public abstract class StreamApiParameters : ApiParameters
+   public abstract class StreamApiParameters : ClientParameters
    {
       /// <summary>
       /// A unique string used to identify the stream in client systems

--- a/OkonkwoOandaV20/OkonkwoOandaV20/TradeLibrary/REST/HttpParameters.cs
+++ b/OkonkwoOandaV20/OkonkwoOandaV20/TradeLibrary/REST/HttpParameters.cs
@@ -27,10 +27,10 @@ namespace OkonkwoOandaV20.TradeLibrary.REST
       {
          if (parameters == null) return;
 
-         if (parameters is ApiParameters apiParameters && !apiParameters.ForInternalRequest)
+         if (parameters is ClientParameters apiParameters && !apiParameters.ForInternalRequest)
             client.TransformObjectValues(parameters, HttpAction.Request);
 
-         jsonSettings = jsonSettings ?? (parameters as ApiParameters)?.JsonSettingsRequest;
+         jsonSettings = jsonSettings ?? (parameters as ClientParameters)?.JsonSettingsRequest;
          jsonSettings = jsonSettings ?? client.JsonSettingsRequest;
          //jsonSettings.ContractResolver = new CamelCasePropertyNamesContractResolver();
          var jsonSerializer = JsonSerializer.CreateDefault(jsonSettings);

--- a/OkonkwoOandaV20/OkonkwoOandaV20/TradeLibrary/Rest20.cs
+++ b/OkonkwoOandaV20/OkonkwoOandaV20/TradeLibrary/Rest20.cs
@@ -23,17 +23,16 @@ namespace OkonkwoOandaV20.TradeLibrary.REST
    public partial class Rest20 : IDisposable
    {
       /// <summary>
-      /// Initialize the middleware that will make calls to Oanda V3 endpoints.
-      /// This method is idempotent. Once initialize, any additional calls will have no effect.
+      /// An instance of the Rest20 client for making requests to Oanda's V20 REST API
       /// </summary>
-      /// <param name="settings">The client TSV3 settings.</param>
-      /// <param name="requestClient">An HttpClient configured to support standard connections.</param>
-      /// <param name="streamsClient">An HttpClient configured to support streaming connections.</param>
-      /// <param name="jsonSerializerSettings">Used to json serialization .. nuff said</param>
+      /// <param name="requestClient">A HttpClient configured to support standard connections.</param>
+      /// <param name="streamsClient">A HttpClient configured to support streaming connections.</param>
+      /// <param name="jsonSettingsRequest">Used to json serialization .. nuff said</param>
+      /// <param name="jsonSettingsResponse">Used to json serialization .. nuff said</param>
+      /// <param name="jsonConverters">Used to convert json objects .. nuff said</param>
       /// <param name="valueTransformers">Used to transform request/response property values</param>
-      /// <param name="credentials">Used to authenticate to Oanda api</param>
-      /// <param name="logger">It's a logger.</param>
-      /// <returns>True, if initialization was successful. False if not successful.</returns>
+      /// <param name="credentials">The credentials to use for authorization.</param>
+      /// <param name="logger">An instance of a logger.</param>
       public Rest20(HttpClient requestClient = null, HttpClient streamsClient = null
          , JsonSerializerSettings jsonSettingsRequest = null, JsonSerializerSettings jsonSettingsResponse = null
          , IList<JsonConverter> jsonConverters = null, IDictionary<string, Action<object>> valueTransformers = null
@@ -54,11 +53,11 @@ namespace OkonkwoOandaV20.TradeLibrary.REST
       #region initialization
 
       /// <summary>
-      /// Initialize the middleware that will make calls to Oanda V3 endpoints.
-      /// This method is idempotent. Once initialize, any additional calls will have no effect.
+      /// Initializes the Rest20 client by setting up JSON converters, serializer settings, value transformers, and authorizing the application using the provided credentials.
       /// </summary>
-      /// <param name="credentials">Used to authenticate to Oanda api</param>
-      /// <returns>True, if initialization was successful. False if not successful.</returns>
+      /// <param name="credentials">The credentials to use for authorization.</param>
+      /// <returns>A task representing the asynchronous operation, with a boolean result indicating whether initialization was successful.</returns>
+      /// <exception cref="ArgumentNullException">Thrown if the provided credentials are null.</exception>
       public virtual async Task<bool> InitializeAsync((EEnvironment environment, string accessToken, string accountId)? credentials)
       {
          await InitializeJsonConverters();
@@ -77,6 +76,10 @@ namespace OkonkwoOandaV20.TradeLibrary.REST
          return true;
       }
 
+      /// <summary>
+      /// Initializes the the json converters for the request and response objects
+      /// </summary>
+      /// <returns>A task representing the asynchronous operation.</returns>
       protected virtual Task InitializeJsonConverters()
       {
          var jsonConverters = JsonConverters ?? new List<JsonConverter>();
@@ -90,9 +93,14 @@ namespace OkonkwoOandaV20.TradeLibrary.REST
          return Task.CompletedTask;
       }
 
+      /// <summary>
+      /// Initializes the JsonSerializerSettings
+      /// </summary>
+      /// <param name="httpObject">The HTTP object type (request or response) for which to initialize the settings.</param>
+      /// <returns>A task representing the asynchronous operation.</returns>
       protected virtual Task InitializeJsonSerializerSettings(string httpAction)
       {
-         JsonSerializerSettings getSettings(IList<JsonConverter> converters) 
+         JsonSerializerSettings getSettings(IList<JsonConverter> converters)
          {
             return new JsonSerializerSettings()
             {
@@ -106,13 +114,14 @@ namespace OkonkwoOandaV20.TradeLibrary.REST
          var jsonConverters = new List<JsonConverter>(JsonConverters);
          //
 
-         if (httpAction != HttpAction.Request)
+         if (httpAction == HttpAction.Request)
          {
             JsonSettingsRequest = JsonSettingsRequest ?? new JsonSerializerSettings();
             jsonConverters.AddRange(JsonSettingsRequest.Converters);
             JsonSettingsRequest = getSettings(jsonConverters);
          }
-         else if (httpAction != HttpAction.Response)
+
+         else if (httpAction == HttpAction.Response)
          {
             JsonSettingsResponse = JsonSettingsResponse ?? new JsonSerializerSettings();
             jsonConverters.AddRange(JsonSettingsResponse.Converters);
@@ -122,6 +131,10 @@ namespace OkonkwoOandaV20.TradeLibrary.REST
          return Task.CompletedTask;
       }
 
+      /// <summary>
+      /// Initalizes the value transformers
+      /// </summary>
+      /// <returns>A task representing the asynchronous operation.</returns>
       protected virtual Task InitializeValueTransformers()
       {
          ValueTransformers = ValueTransformers ?? new Dictionary<string, Action<object>>();
@@ -204,8 +217,12 @@ namespace OkonkwoOandaV20.TradeLibrary.REST
       }
 
       /// <summary>
-      /// New: Sends a streaming request using HttpParameters and returns the raw HttpResponseMessage for streaming consumption.
+      /// Creates a web request to a remote service (uri) and returns the response stream.
       /// </summary>
+      /// <typeparam name="E">The error response type</typeparam>
+      /// <param name="parameters">optional parameters (if provided, it's assumed the uri doesn't contain any)</param>
+      /// <param name="cancellation">A cancellation token that can terminate the request.</param>
+      /// <returns>An HttpResponseMessage representing the response from the remote service.</returns>
       protected virtual async Task<HttpResponseMessage> MakeStreamRequestAsync<E>(HttpParameters parameters, CancellationToken cancellation = default)
          where E : IErrorResponse
       {
@@ -217,10 +234,16 @@ namespace OkonkwoOandaV20.TradeLibrary.REST
       }
 
       /// <summary>
-      /// New: Create an HttpRequestMessage from HttpParameters
+      /// Creates an Http request to a remote service (uri).
       /// </summary>
+      /// <param name="parameters">optional parameters (if provided, it's assumed the uri doesn't contain any)</param>
+      /// <param name="cancellation">A cancellation token that can terminate the request.</param>
+      /// <returns>An HttpRequestMessage representing the request to be sent.</returns>
       protected virtual Task<HttpRequestMessage> CreateHttpRequestAsync(HttpParameters parameters, CancellationToken cancellation)
       {
+         if (!Initialized)
+            throw new InvalidOperationException($"{GetType().Name} client is not initialized. Call InitializeAsync() first.");
+
          if (cancellation.IsCancellationRequested) return default;
 
          string queryString = string.Empty;
@@ -428,24 +451,7 @@ namespace OkonkwoOandaV20.TradeLibrary.REST
 
       #endregion
 
-      public virtual void TransformObjectValues(object inputObject, string httpAction = HttpAction.Response)
-      {
-         if (inputObject == null)
-            return;
-
-         if (httpAction == HttpAction.Request || httpAction == HttpAction.Response)
-         {
-            if (ValueTransformers.TryGetValue(httpAction, out var valueTransformer))
-               valueTransformer.Invoke(inputObject);
-
-            if (httpAction == HttpAction.Request)
-               SimpleObjectValidator.Validate(inputObject);
-
-            return;
-         }
-
-         throw new ArgumentException($"Value transformer type {httpAction} is not supported.");
-      }
+      #region utilities
 
       /// <summary>
       /// Determines if trading is halted for the provided instrument.
@@ -483,6 +489,36 @@ namespace OkonkwoOandaV20.TradeLibrary.REST
 
          return true;
       }
+
+      /// <summary>
+      /// Transforms the values of the properties of the input object based on the specified HTTP action.<br/>
+      /// </summary>
+      /// <param name="inputObject">The object whose property values are to be transformed.</param>
+      /// <param name="httpAction">The HTTP action (request or response) that determines the transformation logic.</param>
+      /// <exception cref="ArgumentException">Thrown when the specified HTTP action is not supported.</exception>
+      public virtual void TransformObjectValues(object inputObject, string httpAction = HttpAction.Response)
+      {
+         if (inputObject == null)
+            return;
+
+         if (httpAction == HttpAction.Request || httpAction == HttpAction.Response)
+         {
+            if (ValueTransformers != null 
+               && ValueTransformers.TryGetValue(httpAction, out var valueTransformer))
+            {
+               valueTransformer.Invoke(inputObject);
+            }
+
+            if (httpAction == HttpAction.Request)
+               SimpleObjectValidator.Validate(inputObject);
+
+            return;
+         }
+
+         throw new ArgumentException($"Value transformer type {httpAction} is not supported.");
+      }
+
+      #endregion
 
       public void Dispose()
       {

--- a/OkonkwoOandaV20/OkonkwoOandaV20/TradeLibrary/Trade/REST/GetOpenTrades.cs
+++ b/OkonkwoOandaV20/OkonkwoOandaV20/TradeLibrary/Trade/REST/GetOpenTrades.cs
@@ -31,7 +31,7 @@ namespace OkonkwoOandaV20.TradeLibrary.REST
       }
    }
 
-   public class OpenTradesParameters : ApiParameters
+   public class OpenTradesParameters : ClientParameters
    {
       /// <summary>
       /// Account Identifier [required]

--- a/OkonkwoOandaV20/OkonkwoOandaV20/TradeLibrary/Trade/REST/GetTrade.cs
+++ b/OkonkwoOandaV20/OkonkwoOandaV20/TradeLibrary/Trade/REST/GetTrade.cs
@@ -29,7 +29,7 @@ namespace OkonkwoOandaV20.TradeLibrary.REST
       }
    }
 
-   public class TradeParameters : ApiParameters
+   public class TradeParameters : ClientParameters
    {
       /// <summary>
       /// Account Identifier [required]

--- a/OkonkwoOandaV20/OkonkwoOandaV20/TradeLibrary/Trade/REST/GetTrades.cs
+++ b/OkonkwoOandaV20/OkonkwoOandaV20/TradeLibrary/Trade/REST/GetTrades.cs
@@ -34,7 +34,7 @@ namespace OkonkwoOandaV20.TradeLibrary.REST
          return response;
       }
 
-      public class TradesParameters : ApiParameters
+      public class TradesParameters : ClientParameters
       {
          /// <summary>
          /// Account Identifier [required]

--- a/OkonkwoOandaV20/OkonkwoOandaV20/TradeLibrary/Trade/REST/PutTradeClientExtensions.cs
+++ b/OkonkwoOandaV20/OkonkwoOandaV20/TradeLibrary/Trade/REST/PutTradeClientExtensions.cs
@@ -31,7 +31,7 @@ namespace OkonkwoOandaV20.TradeLibrary.REST
          return response;
       }
 
-      public class TradeClientExtensionsParameters : ApiParameters
+      public class TradeClientExtensionsParameters : ClientParameters
       {
          /// <summary>
          /// Account Identifier [required]

--- a/OkonkwoOandaV20/OkonkwoOandaV20/TradeLibrary/Trade/REST/PutTradeClose.cs
+++ b/OkonkwoOandaV20/OkonkwoOandaV20/TradeLibrary/Trade/REST/PutTradeClose.cs
@@ -29,7 +29,7 @@ namespace OkonkwoOandaV20.TradeLibrary.REST
          return await MakeRequestAsync<TradeCloseResponse, TradeCloseErrorResponse>(requestParams, cancellation);
       }
 
-      public class TradeCloseParameters : ApiParameters
+      public class TradeCloseParameters : ClientParameters
       {
          /// <summary>
          /// Account Identifier [required]

--- a/OkonkwoOandaV20/OkonkwoOandaV20/TradeLibrary/Trade/REST/PutTradeOrders.cs
+++ b/OkonkwoOandaV20/OkonkwoOandaV20/TradeLibrary/Trade/REST/PutTradeOrders.cs
@@ -33,7 +33,7 @@ namespace OkonkwoOandaV20.TradeLibrary.REST
          return response;
       }
 
-      public class TradeOrdersParameters : ApiParameters
+      public class TradeOrdersParameters : ClientParameters
       {
          public TradeOrdersParameters()
          {

--- a/OkonkwoOandaV20/OkonkwoOandaV20/TradeLibrary/Transaction/REST/GetTransaction.cs
+++ b/OkonkwoOandaV20/OkonkwoOandaV20/TradeLibrary/Transaction/REST/GetTransaction.cs
@@ -33,7 +33,7 @@ namespace OkonkwoOandaV20.TradeLibrary.REST
       }
    }
 
-   public class TransactionParameters : ApiParameters
+   public class TransactionParameters : ClientParameters
    {
       /// <summary>
       /// Account Identifier [required]

--- a/OkonkwoOandaV20/OkonkwoOandaV20/TradeLibrary/Transaction/REST/GetTransactions.cs
+++ b/OkonkwoOandaV20/OkonkwoOandaV20/TradeLibrary/Transaction/REST/GetTransactions.cs
@@ -51,7 +51,7 @@ namespace OkonkwoOandaV20.TradeLibrary.REST
          return response;
       }
 
-      public class TransactionsParameters : ApiParameters
+      public class TransactionsParameters : ClientParameters
       {
          /// <summary>
          /// Account Identifier [required]

--- a/OkonkwoOandaV20/OkonkwoOandaV20/TradeLibrary/Transaction/REST/GetTransactionsByIdRange.cs
+++ b/OkonkwoOandaV20/OkonkwoOandaV20/TradeLibrary/Transaction/REST/GetTransactionsByIdRange.cs
@@ -33,7 +33,7 @@ namespace OkonkwoOandaV20.TradeLibrary.REST
          return response;
       }
 
-      public class TransactionsByIdRangeParameters : ApiParameters
+      public class TransactionsByIdRangeParameters : ClientParameters
       {
          /// <summary>
          /// Account Identifier [required]

--- a/OkonkwoOandaV20/OkonkwoOandaV20/TradeLibrary/Transaction/REST/GetTransactionsSinceId.cs
+++ b/OkonkwoOandaV20/OkonkwoOandaV20/TradeLibrary/Transaction/REST/GetTransactionsSinceId.cs
@@ -32,7 +32,7 @@ namespace OkonkwoOandaV20.TradeLibrary.REST
       }
    }
 
-   public class TransactionsSinceIdParameters : ApiParameters
+   public class TransactionsSinceIdParameters : ClientParameters
    {
       /// <summary>
       /// Account Identifier [required]

--- a/OkonkwoOandaV20/OkonkwoOandaV20/TradeLibrary/Transaction/REST/GetTransactionsStream.cs
+++ b/OkonkwoOandaV20/OkonkwoOandaV20/TradeLibrary/Transaction/REST/GetTransactionsStream.cs
@@ -34,7 +34,7 @@ namespace OkonkwoOandaV20.TradeLibrary.REST
       }
    }
 
-   public class TransactionsStreamParameters : ApiParameters
+   public class TransactionsStreamParameters : ClientParameters
    {
       /// <summary>
       /// Account Identifier [required]

--- a/OkonkwoOandaV20/OkonkwoOandaV20/app.config
+++ b/OkonkwoOandaV20/OkonkwoOandaV20/app.config
@@ -12,7 +12,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.3" newVersion="10.0.0.3" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
@@ -20,19 +20,19 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Extensions.Configuration.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.3" newVersion="10.0.0.3" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Extensions.Hosting.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.3" newVersion="10.0.0.3" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Text.Json" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.3" newVersion="10.0.0.3" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Extensions.Logging.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.3" newVersion="10.0.0.3" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Extensions.Diagnostics.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
@@ -40,15 +40,51 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Extensions.DependencyInjection.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.3" newVersion="10.0.0.3" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Extensions.Primitives" publicKeyToken="adb9793829ddae60" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.3" newVersion="10.0.0.3" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Text.Encodings.Web" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.3" newVersion="10.0.0.3" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Bcl.AsyncInterfaces" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.IdentityModel.Abstractions" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Formats.Asn1" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Security.Cryptography.ProtectedData" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Security.AccessControl" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.1" newVersion="6.0.0.1" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Net.ServerSentEvents" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Memory.Data" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Identity.Client" publicKeyToken="0a613f4dd989e8ae" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.88.0.0" newVersion="4.88.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Identity.Client.Extensions.Msal" publicKeyToken="0a613f4dd989e8ae" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.88.0.0" newVersion="4.88.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/OkonkwoOandaV20/OkonkwoOandaV20/packages.config
+++ b/OkonkwoOandaV20/OkonkwoOandaV20/packages.config
@@ -1,34 +1,35 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Azure.Core" version="1.54.0" targetFramework="net472" />
-  <package id="Microsoft.Bcl.AsyncInterfaces" version="10.0.3" targetFramework="net472" />
-  <package id="Microsoft.Extensions.Configuration.Abstractions" version="10.0.3" targetFramework="net472" />
-  <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="10.0.3" targetFramework="net472" />
-  <package id="Microsoft.Extensions.Diagnostics.Abstractions" version="10.0.3" targetFramework="net472" />
-  <package id="Microsoft.Extensions.FileProviders.Abstractions" version="10.0.3" targetFramework="net472" />
-  <package id="Microsoft.Extensions.Hosting.Abstractions" version="10.0.3" targetFramework="net472" />
-  <package id="Microsoft.Extensions.Logging.Abstractions" version="10.0.3" targetFramework="net472" />
-  <package id="Microsoft.Extensions.Options" version="10.0.3" targetFramework="net472" />
-  <package id="Microsoft.Extensions.Primitives" version="10.0.3" targetFramework="net472" />
-  <package id="Microsoft.Identity.Client" version="4.83.1" targetFramework="net472" />
-  <package id="Microsoft.Identity.Client.Extensions.Msal" version="4.83.1" targetFramework="net472" />
-  <package id="Microsoft.IdentityModel.Abstractions" version="8.14.0" targetFramework="net472" />
-  <package id="Newtonsoft.Json" version="13.0.2" targetFramework="net472" />
+  <package id="Azure.Core" version="1.62.0" targetFramework="net472" />
+  <package id="Microsoft.Bcl.AsyncInterfaces" version="10.0.11" targetFramework="net472" />
+  <package id="Microsoft.Extensions.Configuration.Abstractions" version="10.0.11" targetFramework="net472" />
+  <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="10.0.11" targetFramework="net472" />
+  <package id="Microsoft.Extensions.Diagnostics.Abstractions" version="10.0.11" targetFramework="net472" />
+  <package id="Microsoft.Extensions.FileProviders.Abstractions" version="10.0.11" targetFramework="net472" />
+  <package id="Microsoft.Extensions.Hosting.Abstractions" version="10.0.11" targetFramework="net472" />
+  <package id="Microsoft.Extensions.Logging.Abstractions" version="10.0.11" targetFramework="net472" />
+  <package id="Microsoft.Extensions.Options" version="10.0.11" targetFramework="net472" />
+  <package id="Microsoft.Extensions.Primitives" version="10.0.11" targetFramework="net472" />
+  <package id="Microsoft.Identity.Client" version="4.88.0" targetFramework="net472" />
+  <package id="Microsoft.Identity.Client.Extensions.Msal" version="4.88.0" targetFramework="net472" />
+  <package id="Microsoft.IdentityModel.Abstractions" version="8.22.0" targetFramework="net472" />
+  <package id="Newtonsoft.Json" version="13.0.4" targetFramework="net472" />
   <package id="System.Buffers" version="4.6.1" targetFramework="net472" />
-  <package id="System.ClientModel" version="1.10.0" targetFramework="net472" />
-  <package id="System.Diagnostics.DiagnosticSource" version="10.0.3" targetFramework="net472" />
-  <package id="System.Formats.Asn1" version="8.0.1" targetFramework="net472" />
+  <package id="System.ClientModel" version="1.15.0" targetFramework="net472" />
+  <package id="System.Diagnostics.DiagnosticSource" version="10.0.11" targetFramework="net472" />
+  <package id="System.Formats.Asn1" version="10.0.11" targetFramework="net472" />
   <package id="System.IO.FileSystem.AccessControl" version="5.0.0" targetFramework="net472" />
-  <package id="System.IO.Pipelines" version="10.0.3" targetFramework="net472" />
+  <package id="System.IO.Pipelines" version="10.0.11" targetFramework="net472" />
   <package id="System.Memory" version="4.6.3" targetFramework="net472" />
-  <package id="System.Memory.Data" version="10.0.3" targetFramework="net472" />
+  <package id="System.Memory.Data" version="10.0.11" targetFramework="net472" />
+  <package id="System.Net.ServerSentEvents" version="10.0.11" targetFramework="net472" />
   <package id="System.Numerics.Vectors" version="4.6.1" targetFramework="net472" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.2" targetFramework="net472" />
-  <package id="System.Security.AccessControl" version="5.0.0" targetFramework="net472" />
-  <package id="System.Security.Cryptography.ProtectedData" version="4.5.0" targetFramework="net472" />
+  <package id="System.Security.AccessControl" version="6.0.1" targetFramework="net472" />
+  <package id="System.Security.Cryptography.ProtectedData" version="10.0.11" targetFramework="net472" />
   <package id="System.Security.Principal.Windows" version="5.0.0" targetFramework="net472" />
-  <package id="System.Text.Encodings.Web" version="10.0.3" targetFramework="net472" />
-  <package id="System.Text.Json" version="10.0.3" targetFramework="net472" />
+  <package id="System.Text.Encodings.Web" version="10.0.11" targetFramework="net472" />
+  <package id="System.Text.Json" version="10.0.11" targetFramework="net472" />
   <package id="System.Threading.Tasks.Extensions" version="4.6.3" targetFramework="net472" />
-  <package id="System.ValueTuple" version="4.6.1" targetFramework="net472" />
+  <package id="System.ValueTuple" version="4.6.2" targetFramework="net472" />
 </packages>

--- a/OkonkwoOandaV20/OkonkwoOandaV20App/App.config
+++ b/OkonkwoOandaV20/OkonkwoOandaV20App/App.config
@@ -15,7 +15,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.3" newVersion="10.0.0.3" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
@@ -23,19 +23,19 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Extensions.Configuration.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.3" newVersion="10.0.0.3" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Extensions.Hosting.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.3" newVersion="10.0.0.3" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Text.Json" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.3" newVersion="10.0.0.3" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Extensions.Logging.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.3" newVersion="10.0.0.3" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Extensions.Diagnostics.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
@@ -43,15 +43,59 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Extensions.DependencyInjection.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.3" newVersion="10.0.0.3" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Extensions.Primitives" publicKeyToken="adb9793829ddae60" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.3" newVersion="10.0.0.3" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Text.Encodings.Web" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.3" newVersion="10.0.0.3" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Bcl.AsyncInterfaces" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.IdentityModel.Abstractions" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Formats.Asn1" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Security.Cryptography.ProtectedData" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Security.AccessControl" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.1" newVersion="6.0.0.1" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Net.ServerSentEvents" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Memory.Data" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Identity.Client" publicKeyToken="0a613f4dd989e8ae" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.88.0.0" newVersion="4.88.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Identity.Client.Extensions.Msal" publicKeyToken="0a613f4dd989e8ae" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.88.0.0" newVersion="4.88.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Azure.Core" publicKeyToken="92742159e12e44c8" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.62.0.0" newVersion="1.62.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.ClientModel" publicKeyToken="92742159e12e44c8" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.15.0.0" newVersion="1.15.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/OkonkwoOandaV20/OkonkwoOandaV20App/OkonkwoOandaV20App.csproj
+++ b/OkonkwoOandaV20/OkonkwoOandaV20App/OkonkwoOandaV20App.csproj
@@ -35,77 +35,80 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Azure.Core, Version=1.54.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8, processorArchitecture=MSIL">
-      <HintPath>..\packages\Azure.Core.1.54.0\lib\net472\Azure.Core.dll</HintPath>
+    <Reference Include="Azure.Core, Version=1.62.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8, processorArchitecture=MSIL">
+      <HintPath>..\packages\Azure.Core.1.62.0\lib\net472\Azure.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Azure.Security.KeyVault.Secrets, Version=4.11.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8, processorArchitecture=MSIL">
-      <HintPath>..\packages\Azure.Security.KeyVault.Secrets.4.11.0\lib\netstandard2.0\Azure.Security.KeyVault.Secrets.dll</HintPath>
+    <Reference Include="Azure.Security.KeyVault.Secrets, Version=4.11.1.0, Culture=neutral, PublicKeyToken=92742159e12e44c8, processorArchitecture=MSIL">
+      <HintPath>..\packages\Azure.Security.KeyVault.Secrets.4.11.1\lib\netstandard2.0\Azure.Security.KeyVault.Secrets.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=10.0.0.3, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Bcl.AsyncInterfaces.10.0.3\lib\net462\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
+    <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Bcl.AsyncInterfaces.10.0.11\lib\net462\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Configuration.Abstractions, Version=10.0.0.3, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Configuration.Abstractions.10.0.3\lib\net462\Microsoft.Extensions.Configuration.Abstractions.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Configuration.Abstractions, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Configuration.Abstractions.10.0.11\lib\net462\Microsoft.Extensions.Configuration.Abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=10.0.0.3, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.10.0.3\lib\net462\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.10.0.11\lib\net462\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Diagnostics.Abstractions, Version=10.0.0.3, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Diagnostics.Abstractions.10.0.3\lib\net462\Microsoft.Extensions.Diagnostics.Abstractions.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Diagnostics.Abstractions, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Diagnostics.Abstractions.10.0.11\lib\net462\Microsoft.Extensions.Diagnostics.Abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.FileProviders.Abstractions, Version=10.0.0.3, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.FileProviders.Abstractions.10.0.3\lib\net462\Microsoft.Extensions.FileProviders.Abstractions.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.FileProviders.Abstractions, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.FileProviders.Abstractions.10.0.11\lib\net462\Microsoft.Extensions.FileProviders.Abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Hosting.Abstractions, Version=10.0.0.3, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Hosting.Abstractions.10.0.3\lib\net462\Microsoft.Extensions.Hosting.Abstractions.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Hosting.Abstractions, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Hosting.Abstractions.10.0.11\lib\net462\Microsoft.Extensions.Hosting.Abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Logging.Abstractions, Version=10.0.0.3, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Logging.Abstractions.10.0.3\lib\net462\Microsoft.Extensions.Logging.Abstractions.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Logging.Abstractions, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Logging.Abstractions.10.0.11\lib\net462\Microsoft.Extensions.Logging.Abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Options, Version=10.0.0.3, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Options.10.0.3\lib\net462\Microsoft.Extensions.Options.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Options, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Options.10.0.11\lib\net462\Microsoft.Extensions.Options.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Primitives, Version=10.0.0.3, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Primitives.10.0.3\lib\net462\Microsoft.Extensions.Primitives.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Primitives, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Primitives.10.0.11\lib\net462\Microsoft.Extensions.Primitives.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Identity.Client, Version=4.83.1.0, Culture=neutral, PublicKeyToken=0a613f4dd989e8ae, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Identity.Client.4.83.1\lib\net472\Microsoft.Identity.Client.dll</HintPath>
+    <Reference Include="Microsoft.Identity.Client, Version=4.88.0.0, Culture=neutral, PublicKeyToken=0a613f4dd989e8ae, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Identity.Client.4.88.0\lib\net472\Microsoft.Identity.Client.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Identity.Client.Extensions.Msal, Version=4.83.1.0, Culture=neutral, PublicKeyToken=0a613f4dd989e8ae, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Identity.Client.Extensions.Msal.4.83.1\lib\netstandard2.0\Microsoft.Identity.Client.Extensions.Msal.dll</HintPath>
+    <Reference Include="Microsoft.Identity.Client.Extensions.Msal, Version=4.88.0.0, Culture=neutral, PublicKeyToken=0a613f4dd989e8ae, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Identity.Client.Extensions.Msal.4.88.0\lib\netstandard2.0\Microsoft.Identity.Client.Extensions.Msal.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.IdentityModel.Abstractions, Version=8.14.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.IdentityModel.Abstractions.8.14.0\lib\net472\Microsoft.IdentityModel.Abstractions.dll</HintPath>
+    <Reference Include="Microsoft.IdentityModel.Abstractions, Version=8.22.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.IdentityModel.Abstractions.8.22.0\lib\net472\Microsoft.IdentityModel.Abstractions.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed" />
     <Reference Include="System" />
     <Reference Include="System.Buffers, Version=4.0.5.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Buffers.4.6.1\lib\net462\System.Buffers.dll</HintPath>
     </Reference>
-    <Reference Include="System.ClientModel, Version=1.10.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.ClientModel.1.10.0\lib\netstandard2.0\System.ClientModel.dll</HintPath>
+    <Reference Include="System.ClientModel, Version=1.15.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.ClientModel.1.15.0\lib\netstandard2.0\System.ClientModel.dll</HintPath>
     </Reference>
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Diagnostics.DiagnosticSource, Version=10.0.0.3, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Diagnostics.DiagnosticSource.10.0.3\lib\net462\System.Diagnostics.DiagnosticSource.dll</HintPath>
+    <Reference Include="System.Diagnostics.DiagnosticSource, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Diagnostics.DiagnosticSource.10.0.11\lib\net462\System.Diagnostics.DiagnosticSource.dll</HintPath>
     </Reference>
     <Reference Include="System.Drawing" />
-    <Reference Include="System.Formats.Asn1, Version=8.0.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Formats.Asn1.8.0.1\lib\net462\System.Formats.Asn1.dll</HintPath>
+    <Reference Include="System.Formats.Asn1, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Formats.Asn1.10.0.11\lib\net462\System.Formats.Asn1.dll</HintPath>
     </Reference>
     <Reference Include="System.IdentityModel" />
     <Reference Include="System.IO.FileSystem.AccessControl, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.IO.FileSystem.AccessControl.5.0.0\lib\net461\System.IO.FileSystem.AccessControl.dll</HintPath>
     </Reference>
-    <Reference Include="System.IO.Pipelines, Version=10.0.0.3, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.IO.Pipelines.10.0.3\lib\net462\System.IO.Pipelines.dll</HintPath>
+    <Reference Include="System.IO.Pipelines, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IO.Pipelines.10.0.11\lib\net462\System.IO.Pipelines.dll</HintPath>
     </Reference>
     <Reference Include="System.Memory, Version=4.0.5.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Memory.4.6.3\lib\net462\System.Memory.dll</HintPath>
     </Reference>
-    <Reference Include="System.Memory.Data, Version=10.0.0.3, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Memory.Data.10.0.3\lib\net462\System.Memory.Data.dll</HintPath>
+    <Reference Include="System.Memory.Data, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Memory.Data.10.0.11\lib\net462\System.Memory.Data.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Net.ServerSentEvents, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Net.ServerSentEvents.10.0.11\lib\net462\System.Net.ServerSentEvents.dll</HintPath>
     </Reference>
     <Reference Include="System.Numerics" />
     <Reference Include="System.Numerics.Vectors, Version=4.1.6.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
@@ -115,24 +118,25 @@
       <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.6.1.2\lib\net462\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
     <Reference Include="System.Security" />
-    <Reference Include="System.Security.AccessControl, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Security.AccessControl.5.0.0\lib\net461\System.Security.AccessControl.dll</HintPath>
+    <Reference Include="System.Security.AccessControl, Version=6.0.0.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.AccessControl.6.0.1\lib\net461\System.Security.AccessControl.dll</HintPath>
     </Reference>
-    <Reference Include="System.Security.Cryptography.ProtectedData, Version=4.0.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Security.Cryptography.ProtectedData.4.5.0\lib\net461\System.Security.Cryptography.ProtectedData.dll</HintPath>
+    <Reference Include="System.Security.Cryptography.ProtectedData, Version=10.0.0.11, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Cryptography.ProtectedData.10.0.11\lib\net462\System.Security.Cryptography.ProtectedData.dll</HintPath>
     </Reference>
     <Reference Include="System.Security.Principal.Windows, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Security.Principal.Windows.5.0.0\lib\net461\System.Security.Principal.Windows.dll</HintPath>
     </Reference>
-    <Reference Include="System.Text.Encodings.Web, Version=10.0.0.3, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Text.Encodings.Web.10.0.3\lib\net462\System.Text.Encodings.Web.dll</HintPath>
+    <Reference Include="System.Text.Encodings.Web, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Text.Encodings.Web.10.0.11\lib\net462\System.Text.Encodings.Web.dll</HintPath>
     </Reference>
-    <Reference Include="System.Text.Json, Version=10.0.0.3, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Text.Json.10.0.3\lib\net462\System.Text.Json.dll</HintPath>
+    <Reference Include="System.Text.Json, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Text.Json.10.0.11\lib\net462\System.Text.Json.dll</HintPath>
     </Reference>
     <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.4.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Threading.Tasks.Extensions.4.6.3\lib\net462\System.Threading.Tasks.Extensions.dll</HintPath>
     </Reference>
+    <Reference Include="System.ValueTuple" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
@@ -156,11 +160,11 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\System.ValueTuple.4.6.1\build\net471\System.ValueTuple.targets" Condition="Exists('..\packages\System.ValueTuple.4.6.1\build\net471\System.ValueTuple.targets')" />
+  <Import Project="..\packages\System.ValueTuple.4.6.2\build\net471\System.ValueTuple.targets" Condition="Exists('..\packages\System.ValueTuple.4.6.2\build\net471\System.ValueTuple.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\System.ValueTuple.4.6.1\build\net471\System.ValueTuple.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\System.ValueTuple.4.6.1\build\net471\System.ValueTuple.targets'))" />
+    <Error Condition="!Exists('..\packages\System.ValueTuple.4.6.2\build\net471\System.ValueTuple.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\System.ValueTuple.4.6.2\build\net471\System.ValueTuple.targets'))" />
   </Target>
 </Project>

--- a/OkonkwoOandaV20/OkonkwoOandaV20App/Program.cs
+++ b/OkonkwoOandaV20/OkonkwoOandaV20App/Program.cs
@@ -1,7 +1,6 @@
 ﻿using Azure.Core;
 using Azure.Identity;
 using Azure.Security.KeyVault.Secrets;
-using OkonkwoOandaV20.Framework;
 using OkonkwoOandaV20.Framework.Factories;
 using OkonkwoOandaV20.TradeLibrary.REST;
 using OkonkwoOandaV20.TradeLibrary.REST.OrderRequests;
@@ -42,7 +41,7 @@ namespace OkonkwoOandaV20App
       private static void SetApiCredentials()
       {
          var keyVaultUri = $"https://marketminerkvdev.vault.azure.net/";
-         var keyVaultClient = new SecretClient(new Uri(keyVaultUri), Utilities.GetAzureCredential());
+         var keyVaultClient = new SecretClient(new Uri(keyVaultUri), GetAzureCredential());
          var keyVaultSecret = keyVaultClient.GetSecret("OandaCredentials");
          var keyVaultValue = keyVaultSecret.Value?.Value;
          //
@@ -186,6 +185,15 @@ namespace OkonkwoOandaV20App
          _transactionsSession.StopSession();
       }
       #endregion
+
+      private static TokenCredential GetAzureCredential(bool isLocalEnvironment = true)
+      {
+         var credentialOptions = new DefaultAzureCredentialOptions
+         {
+            ExcludeManagedIdentityCredential = isLocalEnvironment
+         };
+         return new DefaultAzureCredential(credentialOptions);
+      }
 
       static void WriteNewLine(string message)
       {

--- a/OkonkwoOandaV20/OkonkwoOandaV20App/packages.config
+++ b/OkonkwoOandaV20/OkonkwoOandaV20App/packages.config
@@ -1,34 +1,35 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Azure.Core" version="1.54.0" targetFramework="net472" />
-  <package id="Azure.Security.KeyVault.Secrets" version="4.11.0" targetFramework="net472" />
-  <package id="Microsoft.Bcl.AsyncInterfaces" version="10.0.3" targetFramework="net472" />
-  <package id="Microsoft.Extensions.Configuration.Abstractions" version="10.0.3" targetFramework="net472" />
-  <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="10.0.3" targetFramework="net472" />
-  <package id="Microsoft.Extensions.Diagnostics.Abstractions" version="10.0.3" targetFramework="net472" />
-  <package id="Microsoft.Extensions.FileProviders.Abstractions" version="10.0.3" targetFramework="net472" />
-  <package id="Microsoft.Extensions.Hosting.Abstractions" version="10.0.3" targetFramework="net472" />
-  <package id="Microsoft.Extensions.Logging.Abstractions" version="10.0.3" targetFramework="net472" />
-  <package id="Microsoft.Extensions.Options" version="10.0.3" targetFramework="net472" />
-  <package id="Microsoft.Extensions.Primitives" version="10.0.3" targetFramework="net472" />
-  <package id="Microsoft.Identity.Client" version="4.83.1" targetFramework="net472" />
-  <package id="Microsoft.Identity.Client.Extensions.Msal" version="4.83.1" targetFramework="net472" />
-  <package id="Microsoft.IdentityModel.Abstractions" version="8.14.0" targetFramework="net472" />
+  <package id="Azure.Core" version="1.62.0" targetFramework="net472" />
+  <package id="Azure.Security.KeyVault.Secrets" version="4.11.1" targetFramework="net472" />
+  <package id="Microsoft.Bcl.AsyncInterfaces" version="10.0.11" targetFramework="net472" />
+  <package id="Microsoft.Extensions.Configuration.Abstractions" version="10.0.11" targetFramework="net472" />
+  <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="10.0.11" targetFramework="net472" />
+  <package id="Microsoft.Extensions.Diagnostics.Abstractions" version="10.0.11" targetFramework="net472" />
+  <package id="Microsoft.Extensions.FileProviders.Abstractions" version="10.0.11" targetFramework="net472" />
+  <package id="Microsoft.Extensions.Hosting.Abstractions" version="10.0.11" targetFramework="net472" />
+  <package id="Microsoft.Extensions.Logging.Abstractions" version="10.0.11" targetFramework="net472" />
+  <package id="Microsoft.Extensions.Options" version="10.0.11" targetFramework="net472" />
+  <package id="Microsoft.Extensions.Primitives" version="10.0.11" targetFramework="net472" />
+  <package id="Microsoft.Identity.Client" version="4.88.0" targetFramework="net472" />
+  <package id="Microsoft.Identity.Client.Extensions.Msal" version="4.88.0" targetFramework="net472" />
+  <package id="Microsoft.IdentityModel.Abstractions" version="8.22.0" targetFramework="net472" />
   <package id="System.Buffers" version="4.6.1" targetFramework="net472" />
-  <package id="System.ClientModel" version="1.10.0" targetFramework="net472" />
-  <package id="System.Diagnostics.DiagnosticSource" version="10.0.3" targetFramework="net472" />
-  <package id="System.Formats.Asn1" version="8.0.1" targetFramework="net472" />
+  <package id="System.ClientModel" version="1.15.0" targetFramework="net472" />
+  <package id="System.Diagnostics.DiagnosticSource" version="10.0.11" targetFramework="net472" />
+  <package id="System.Formats.Asn1" version="10.0.11" targetFramework="net472" />
   <package id="System.IO.FileSystem.AccessControl" version="5.0.0" targetFramework="net472" />
-  <package id="System.IO.Pipelines" version="10.0.3" targetFramework="net472" />
+  <package id="System.IO.Pipelines" version="10.0.11" targetFramework="net472" />
   <package id="System.Memory" version="4.6.3" targetFramework="net472" />
-  <package id="System.Memory.Data" version="10.0.3" targetFramework="net472" />
+  <package id="System.Memory.Data" version="10.0.11" targetFramework="net472" />
+  <package id="System.Net.ServerSentEvents" version="10.0.11" targetFramework="net472" />
   <package id="System.Numerics.Vectors" version="4.6.1" targetFramework="net472" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.2" targetFramework="net472" />
-  <package id="System.Security.AccessControl" version="5.0.0" targetFramework="net472" />
-  <package id="System.Security.Cryptography.ProtectedData" version="4.5.0" targetFramework="net472" />
+  <package id="System.Security.AccessControl" version="6.0.1" targetFramework="net472" />
+  <package id="System.Security.Cryptography.ProtectedData" version="10.0.11" targetFramework="net472" />
   <package id="System.Security.Principal.Windows" version="5.0.0" targetFramework="net472" />
-  <package id="System.Text.Encodings.Web" version="10.0.3" targetFramework="net472" />
-  <package id="System.Text.Json" version="10.0.3" targetFramework="net472" />
+  <package id="System.Text.Encodings.Web" version="10.0.11" targetFramework="net472" />
+  <package id="System.Text.Json" version="10.0.11" targetFramework="net472" />
   <package id="System.Threading.Tasks.Extensions" version="4.6.3" targetFramework="net472" />
-  <package id="System.ValueTuple" version="4.6.1" targetFramework="net472" />
+  <package id="System.ValueTuple" version="4.6.2" targetFramework="net472" />
 </packages>

--- a/OkonkwoOandaV20/OkonkwoOandaV20Tests/OkonkwoOandaV20Tests.csproj
+++ b/OkonkwoOandaV20/OkonkwoOandaV20Tests/OkonkwoOandaV20Tests.csproj
@@ -38,81 +38,84 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Azure.Core, Version=1.54.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8, processorArchitecture=MSIL">
-      <HintPath>..\packages\Azure.Core.1.54.0\lib\net472\Azure.Core.dll</HintPath>
+    <Reference Include="Azure.Core, Version=1.62.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8, processorArchitecture=MSIL">
+      <HintPath>..\packages\Azure.Core.1.62.0\lib\net472\Azure.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Azure.Security.KeyVault.Secrets, Version=4.11.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8, processorArchitecture=MSIL">
-      <HintPath>..\packages\Azure.Security.KeyVault.Secrets.4.11.0\lib\netstandard2.0\Azure.Security.KeyVault.Secrets.dll</HintPath>
+    <Reference Include="Azure.Security.KeyVault.Secrets, Version=4.11.1.0, Culture=neutral, PublicKeyToken=92742159e12e44c8, processorArchitecture=MSIL">
+      <HintPath>..\packages\Azure.Security.KeyVault.Secrets.4.11.1\lib\netstandard2.0\Azure.Security.KeyVault.Secrets.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=10.0.0.3, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Bcl.AsyncInterfaces.10.0.3\lib\net462\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
+    <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Bcl.AsyncInterfaces.10.0.11\lib\net462\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="Microsoft.Extensions.Configuration.Abstractions, Version=10.0.0.3, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Configuration.Abstractions.10.0.3\lib\net462\Microsoft.Extensions.Configuration.Abstractions.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Configuration.Abstractions, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Configuration.Abstractions.10.0.11\lib\net462\Microsoft.Extensions.Configuration.Abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=10.0.0.3, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.10.0.3\lib\net462\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.10.0.11\lib\net462\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Diagnostics.Abstractions, Version=10.0.0.3, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Diagnostics.Abstractions.10.0.3\lib\net462\Microsoft.Extensions.Diagnostics.Abstractions.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Diagnostics.Abstractions, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Diagnostics.Abstractions.10.0.11\lib\net462\Microsoft.Extensions.Diagnostics.Abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.FileProviders.Abstractions, Version=10.0.0.3, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.FileProviders.Abstractions.10.0.3\lib\net462\Microsoft.Extensions.FileProviders.Abstractions.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.FileProviders.Abstractions, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.FileProviders.Abstractions.10.0.11\lib\net462\Microsoft.Extensions.FileProviders.Abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Hosting.Abstractions, Version=10.0.0.3, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Hosting.Abstractions.10.0.3\lib\net462\Microsoft.Extensions.Hosting.Abstractions.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Hosting.Abstractions, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Hosting.Abstractions.10.0.11\lib\net462\Microsoft.Extensions.Hosting.Abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Logging.Abstractions, Version=10.0.0.3, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Logging.Abstractions.10.0.3\lib\net462\Microsoft.Extensions.Logging.Abstractions.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Logging.Abstractions, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Logging.Abstractions.10.0.11\lib\net462\Microsoft.Extensions.Logging.Abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Options, Version=10.0.0.3, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Options.10.0.3\lib\net462\Microsoft.Extensions.Options.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Options, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Options.10.0.11\lib\net462\Microsoft.Extensions.Options.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Primitives, Version=10.0.0.3, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Primitives.10.0.3\lib\net462\Microsoft.Extensions.Primitives.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Primitives, Version=10.0.0.11, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Primitives.10.0.11\lib\net462\Microsoft.Extensions.Primitives.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Identity.Client, Version=4.83.1.0, Culture=neutral, PublicKeyToken=0a613f4dd989e8ae, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Identity.Client.4.83.1\lib\net472\Microsoft.Identity.Client.dll</HintPath>
+    <Reference Include="Microsoft.Identity.Client, Version=4.88.0.0, Culture=neutral, PublicKeyToken=0a613f4dd989e8ae, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Identity.Client.4.88.0\lib\net472\Microsoft.Identity.Client.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Identity.Client.Extensions.Msal, Version=4.83.1.0, Culture=neutral, PublicKeyToken=0a613f4dd989e8ae, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Identity.Client.Extensions.Msal.4.83.1\lib\netstandard2.0\Microsoft.Identity.Client.Extensions.Msal.dll</HintPath>
+    <Reference Include="Microsoft.Identity.Client.Extensions.Msal, Version=4.88.0.0, Culture=neutral, PublicKeyToken=0a613f4dd989e8ae, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Identity.Client.Extensions.Msal.4.88.0\lib\netstandard2.0\Microsoft.Identity.Client.Extensions.Msal.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.IdentityModel.Abstractions, Version=8.14.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.IdentityModel.Abstractions.8.14.0\lib\net472\Microsoft.IdentityModel.Abstractions.dll</HintPath>
+    <Reference Include="Microsoft.IdentityModel.Abstractions, Version=8.22.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.IdentityModel.Abstractions.8.22.0\lib\net472\Microsoft.IdentityModel.Abstractions.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed" />
     <Reference Include="System" />
     <Reference Include="System.Buffers, Version=4.0.5.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Buffers.4.6.1\lib\net462\System.Buffers.dll</HintPath>
     </Reference>
-    <Reference Include="System.ClientModel, Version=1.10.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.ClientModel.1.10.0\lib\netstandard2.0\System.ClientModel.dll</HintPath>
+    <Reference Include="System.ClientModel, Version=1.15.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.ClientModel.1.15.0\lib\netstandard2.0\System.ClientModel.dll</HintPath>
     </Reference>
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Data" />
     <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="System.Diagnostics.DiagnosticSource, Version=10.0.0.3, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Diagnostics.DiagnosticSource.10.0.3\lib\net462\System.Diagnostics.DiagnosticSource.dll</HintPath>
+    <Reference Include="System.Diagnostics.DiagnosticSource, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Diagnostics.DiagnosticSource.10.0.11\lib\net462\System.Diagnostics.DiagnosticSource.dll</HintPath>
     </Reference>
     <Reference Include="System.Drawing" />
-    <Reference Include="System.Formats.Asn1, Version=8.0.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Formats.Asn1.8.0.1\lib\net462\System.Formats.Asn1.dll</HintPath>
+    <Reference Include="System.Formats.Asn1, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Formats.Asn1.10.0.11\lib\net462\System.Formats.Asn1.dll</HintPath>
     </Reference>
     <Reference Include="System.IdentityModel" />
     <Reference Include="System.IO.FileSystem.AccessControl, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.IO.FileSystem.AccessControl.5.0.0\lib\net461\System.IO.FileSystem.AccessControl.dll</HintPath>
     </Reference>
-    <Reference Include="System.IO.Pipelines, Version=10.0.0.3, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.IO.Pipelines.10.0.3\lib\net462\System.IO.Pipelines.dll</HintPath>
+    <Reference Include="System.IO.Pipelines, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IO.Pipelines.10.0.11\lib\net462\System.IO.Pipelines.dll</HintPath>
     </Reference>
     <Reference Include="System.Memory, Version=4.0.5.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Memory.4.6.3\lib\net462\System.Memory.dll</HintPath>
     </Reference>
-    <Reference Include="System.Memory.Data, Version=10.0.0.3, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Memory.Data.10.0.3\lib\net462\System.Memory.Data.dll</HintPath>
+    <Reference Include="System.Memory.Data, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Memory.Data.10.0.11\lib\net462\System.Memory.Data.dll</HintPath>
     </Reference>
     <Reference Include="System.Net.Http" />
+    <Reference Include="System.Net.ServerSentEvents, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Net.ServerSentEvents.10.0.11\lib\net462\System.Net.ServerSentEvents.dll</HintPath>
+    </Reference>
     <Reference Include="System.Numerics" />
     <Reference Include="System.Numerics.Vectors, Version=4.1.6.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Numerics.Vectors.4.6.1\lib\net462\System.Numerics.Vectors.dll</HintPath>
@@ -121,24 +124,25 @@
       <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.6.1.2\lib\net462\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
     <Reference Include="System.Security" />
-    <Reference Include="System.Security.AccessControl, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Security.AccessControl.5.0.0\lib\net461\System.Security.AccessControl.dll</HintPath>
+    <Reference Include="System.Security.AccessControl, Version=6.0.0.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.AccessControl.6.0.1\lib\net461\System.Security.AccessControl.dll</HintPath>
     </Reference>
-    <Reference Include="System.Security.Cryptography.ProtectedData, Version=4.0.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Security.Cryptography.ProtectedData.4.5.0\lib\net461\System.Security.Cryptography.ProtectedData.dll</HintPath>
+    <Reference Include="System.Security.Cryptography.ProtectedData, Version=10.0.0.11, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Cryptography.ProtectedData.10.0.11\lib\net462\System.Security.Cryptography.ProtectedData.dll</HintPath>
     </Reference>
     <Reference Include="System.Security.Principal.Windows, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Security.Principal.Windows.5.0.0\lib\net461\System.Security.Principal.Windows.dll</HintPath>
     </Reference>
-    <Reference Include="System.Text.Encodings.Web, Version=10.0.0.3, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Text.Encodings.Web.10.0.3\lib\net462\System.Text.Encodings.Web.dll</HintPath>
+    <Reference Include="System.Text.Encodings.Web, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Text.Encodings.Web.10.0.11\lib\net462\System.Text.Encodings.Web.dll</HintPath>
     </Reference>
-    <Reference Include="System.Text.Json, Version=10.0.0.3, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Text.Json.10.0.3\lib\net462\System.Text.Json.dll</HintPath>
+    <Reference Include="System.Text.Json, Version=10.0.0.11, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Text.Json.10.0.11\lib\net462\System.Text.Json.dll</HintPath>
     </Reference>
     <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.4.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Threading.Tasks.Extensions.4.6.3\lib\net462\System.Threading.Tasks.Extensions.dll</HintPath>
     </Reference>
+    <Reference Include="System.ValueTuple" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
@@ -161,6 +165,7 @@
     <Compile Include="Restv20Test.cs" />
     <Compile Include="Restv20TestBase.cs" />
     <Compile Include="Restv20TestResult.cs" />
+    <Compile Include="Utilities.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\OkonkwoOandaV20\OkonkwoOandaV20.csproj">
@@ -192,12 +197,12 @@
   </Choose>
   <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\System.ValueTuple.4.6.1\build\net471\System.ValueTuple.targets" Condition="Exists('..\packages\System.ValueTuple.4.6.1\build\net471\System.ValueTuple.targets')" />
+  <Import Project="..\packages\System.ValueTuple.4.6.2\build\net471\System.ValueTuple.targets" Condition="Exists('..\packages\System.ValueTuple.4.6.2\build\net471\System.ValueTuple.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\System.ValueTuple.4.6.1\build\net471\System.ValueTuple.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\System.ValueTuple.4.6.1\build\net471\System.ValueTuple.targets'))" />
+    <Error Condition="!Exists('..\packages\System.ValueTuple.4.6.2\build\net471\System.ValueTuple.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\System.ValueTuple.4.6.2\build\net471\System.ValueTuple.targets'))" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/OkonkwoOandaV20/OkonkwoOandaV20Tests/RestV20Operations.cs
+++ b/OkonkwoOandaV20/OkonkwoOandaV20Tests/RestV20Operations.cs
@@ -1221,8 +1221,6 @@ namespace OkonkwoOandaV20Tests
          }
 
          _gotTransaction = true;
-
-         // Signal the waiting task
          _transactionReceivedTcs.TrySetResult(true);
       }
 
@@ -1238,17 +1236,15 @@ namespace OkonkwoOandaV20Tests
 
          _gotPrice = false;
          _gotPriceTick = false;
-         _priceReceivedTcs = new TaskCompletionSource<bool>(
-             TaskCreationOptions.RunContinuationsAsynchronously);
+         _priceReceivedTcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
          session.DataReceived += OnPricingReceived;
          session.StartSession(m_CancellationToken);
 
-         // Wait up to 30 seconds for first price tick
+         // Wait up to 30 seconds
          var priceReceivedTask = _priceReceivedTcs.Task;
          var completedTask = await Task.WhenAny(priceReceivedTask, Task.Delay(30000));
 
-         // Stop the session cleanly
          session.StopSession();
 
          m_Results.Verify("18.0", _gotPriceTick, "Pricing stream is functioning.");
@@ -1306,13 +1302,13 @@ namespace OkonkwoOandaV20Tests
       /// <summary>
       /// Reads the api key from a supplied file name
       /// </summary>
-      /// <returns></returns>
+      /// <returns>A task representing the asynchronous operation, with a tuple containing the environment, access token, and account ID.</returns>
       private static Task<(EEnvironment environment, string accessToken, string accountId)>
          GetApiCredentials()
       {
          var keyVaultUri = $"https://marketminerkvdev.vault.azure.net/";
          var keyVaultClient = new SecretClient(new Uri(keyVaultUri), Utilities.GetAzureCredential());
-         var keyVaultSecret = keyVaultClient.GetSecret("OandaCredentials");
+         var keyVaultSecret = keyVaultClient.GetSecret("OandaCredentialsPR");
          var keyVaultValue = keyVaultSecret.Value?.Value;
          //
 

--- a/OkonkwoOandaV20/OkonkwoOandaV20Tests/Utilities.cs
+++ b/OkonkwoOandaV20/OkonkwoOandaV20Tests/Utilities.cs
@@ -1,0 +1,17 @@
+﻿using Azure.Core;
+using Azure.Identity;
+
+namespace OkonkwoOandaV20Tests
+{
+   internal static class Utilities
+   {
+      internal static TokenCredential GetAzureCredential(bool isLocalEnvironment = true)
+      {
+         var credentialOptions = new DefaultAzureCredentialOptions
+         {
+            ExcludeManagedIdentityCredential = isLocalEnvironment
+         };
+         return new DefaultAzureCredential(credentialOptions);
+      }
+   }
+}

--- a/OkonkwoOandaV20/OkonkwoOandaV20Tests/app.config
+++ b/OkonkwoOandaV20/OkonkwoOandaV20Tests/app.config
@@ -12,7 +12,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.3" newVersion="10.0.0.3" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
@@ -20,19 +20,19 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Extensions.Configuration.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.3" newVersion="10.0.0.3" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Extensions.Hosting.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.3" newVersion="10.0.0.3" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Text.Json" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.3" newVersion="10.0.0.3" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Extensions.Logging.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.3" newVersion="10.0.0.3" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Extensions.Diagnostics.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
@@ -40,15 +40,59 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Extensions.DependencyInjection.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.3" newVersion="10.0.0.3" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Extensions.Primitives" publicKeyToken="adb9793829ddae60" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.3" newVersion="10.0.0.3" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Text.Encodings.Web" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.3" newVersion="10.0.0.3" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Bcl.AsyncInterfaces" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.IdentityModel.Abstractions" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Formats.Asn1" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Security.Cryptography.ProtectedData" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Security.AccessControl" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.1" newVersion="6.0.0.1" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Net.ServerSentEvents" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Memory.Data" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Identity.Client" publicKeyToken="0a613f4dd989e8ae" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.88.0.0" newVersion="4.88.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Identity.Client.Extensions.Msal" publicKeyToken="0a613f4dd989e8ae" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.88.0.0" newVersion="4.88.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Azure.Core" publicKeyToken="92742159e12e44c8" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.62.0.0" newVersion="1.62.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.ClientModel" publicKeyToken="92742159e12e44c8" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.15.0.0" newVersion="1.15.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/OkonkwoOandaV20/OkonkwoOandaV20Tests/packages.config
+++ b/OkonkwoOandaV20/OkonkwoOandaV20Tests/packages.config
@@ -1,34 +1,35 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Azure.Core" version="1.54.0" targetFramework="net472" />
-  <package id="Azure.Security.KeyVault.Secrets" version="4.11.0" targetFramework="net472" />
-  <package id="Microsoft.Bcl.AsyncInterfaces" version="10.0.3" targetFramework="net472" />
-  <package id="Microsoft.Extensions.Configuration.Abstractions" version="10.0.3" targetFramework="net472" />
-  <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="10.0.3" targetFramework="net472" />
-  <package id="Microsoft.Extensions.Diagnostics.Abstractions" version="10.0.3" targetFramework="net472" />
-  <package id="Microsoft.Extensions.FileProviders.Abstractions" version="10.0.3" targetFramework="net472" />
-  <package id="Microsoft.Extensions.Hosting.Abstractions" version="10.0.3" targetFramework="net472" />
-  <package id="Microsoft.Extensions.Logging.Abstractions" version="10.0.3" targetFramework="net472" />
-  <package id="Microsoft.Extensions.Options" version="10.0.3" targetFramework="net472" />
-  <package id="Microsoft.Extensions.Primitives" version="10.0.3" targetFramework="net472" />
-  <package id="Microsoft.Identity.Client" version="4.83.1" targetFramework="net472" />
-  <package id="Microsoft.Identity.Client.Extensions.Msal" version="4.83.1" targetFramework="net472" />
-  <package id="Microsoft.IdentityModel.Abstractions" version="8.14.0" targetFramework="net472" />
+  <package id="Azure.Core" version="1.62.0" targetFramework="net472" />
+  <package id="Azure.Security.KeyVault.Secrets" version="4.11.1" targetFramework="net472" />
+  <package id="Microsoft.Bcl.AsyncInterfaces" version="10.0.11" targetFramework="net472" />
+  <package id="Microsoft.Extensions.Configuration.Abstractions" version="10.0.11" targetFramework="net472" />
+  <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="10.0.11" targetFramework="net472" />
+  <package id="Microsoft.Extensions.Diagnostics.Abstractions" version="10.0.11" targetFramework="net472" />
+  <package id="Microsoft.Extensions.FileProviders.Abstractions" version="10.0.11" targetFramework="net472" />
+  <package id="Microsoft.Extensions.Hosting.Abstractions" version="10.0.11" targetFramework="net472" />
+  <package id="Microsoft.Extensions.Logging.Abstractions" version="10.0.11" targetFramework="net472" />
+  <package id="Microsoft.Extensions.Options" version="10.0.11" targetFramework="net472" />
+  <package id="Microsoft.Extensions.Primitives" version="10.0.11" targetFramework="net472" />
+  <package id="Microsoft.Identity.Client" version="4.88.0" targetFramework="net472" />
+  <package id="Microsoft.Identity.Client.Extensions.Msal" version="4.88.0" targetFramework="net472" />
+  <package id="Microsoft.IdentityModel.Abstractions" version="8.22.0" targetFramework="net472" />
   <package id="System.Buffers" version="4.6.1" targetFramework="net472" />
-  <package id="System.ClientModel" version="1.10.0" targetFramework="net472" />
-  <package id="System.Diagnostics.DiagnosticSource" version="10.0.3" targetFramework="net472" />
-  <package id="System.Formats.Asn1" version="8.0.1" targetFramework="net472" />
+  <package id="System.ClientModel" version="1.15.0" targetFramework="net472" />
+  <package id="System.Diagnostics.DiagnosticSource" version="10.0.11" targetFramework="net472" />
+  <package id="System.Formats.Asn1" version="10.0.11" targetFramework="net472" />
   <package id="System.IO.FileSystem.AccessControl" version="5.0.0" targetFramework="net472" />
-  <package id="System.IO.Pipelines" version="10.0.3" targetFramework="net472" />
+  <package id="System.IO.Pipelines" version="10.0.11" targetFramework="net472" />
   <package id="System.Memory" version="4.6.3" targetFramework="net472" />
-  <package id="System.Memory.Data" version="10.0.3" targetFramework="net472" />
+  <package id="System.Memory.Data" version="10.0.11" targetFramework="net472" />
+  <package id="System.Net.ServerSentEvents" version="10.0.11" targetFramework="net472" />
   <package id="System.Numerics.Vectors" version="4.6.1" targetFramework="net472" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.2" targetFramework="net472" />
-  <package id="System.Security.AccessControl" version="5.0.0" targetFramework="net472" />
-  <package id="System.Security.Cryptography.ProtectedData" version="4.5.0" targetFramework="net472" />
+  <package id="System.Security.AccessControl" version="6.0.1" targetFramework="net472" />
+  <package id="System.Security.Cryptography.ProtectedData" version="10.0.11" targetFramework="net472" />
   <package id="System.Security.Principal.Windows" version="5.0.0" targetFramework="net472" />
-  <package id="System.Text.Encodings.Web" version="10.0.3" targetFramework="net472" />
-  <package id="System.Text.Json" version="10.0.3" targetFramework="net472" />
+  <package id="System.Text.Encodings.Web" version="10.0.11" targetFramework="net472" />
+  <package id="System.Text.Json" version="10.0.11" targetFramework="net472" />
   <package id="System.Threading.Tasks.Extensions" version="4.6.3" targetFramework="net472" />
-  <package id="System.ValueTuple" version="4.6.1" targetFramework="net472" />
+  <package id="System.ValueTuple" version="4.6.2" targetFramework="net472" />
 </packages>


### PR DESCRIPTION
This pull request primarily updates the parameter class naming convention from `ApiParameters` to `ClientParameters` across the codebase, and also upgrades several NuGet package dependencies to more recent versions. Additionally, it updates project file references to match these dependency changes and renames a file for clarity.

**Parameter Class Refactoring:**

- Replaced all usages and definitions of `ApiParameters` with `ClientParameters` in parameter classes related to accounts, instruments, and orders, ensuring consistency and clarity in naming throughout the codebase. [[1]](diffhunk://#diff-ab17904c60f5bdf9c382f91ff53e8c9e49d543715efee592f7b24b8cab82213aL34-R34) [[2]](diffhunk://#diff-aa65660d7bc46099080ec89d90e833034826b30667dfb37972bf3067fbf605bdL118-R118) [[3]](diffhunk://#diff-552452f4bff33f4b454e7246072de70c356a88f13ad5286ed72221e16e7ba709L36-R36) [[4]](diffhunk://#diff-d669603b171264cc2e051db71d721f391ae85dd4178731e3a5a79532e12a7a91L40-R40) [[5]](diffhunk://#diff-7b64b65ae066db434804be328ffd4886d903ac033489264968698376f6e9ef2aL37-R37) [[6]](diffhunk://#diff-6422af7ce0e8149b57cfd3b928aa554c62cffca7b8f676c326bb9e7bf4f254eeL37-R37) [[7]](diffhunk://#diff-20d042bfea767b0e11f8c8974a7accc78a2984f46f4982cf1490e6fb4606de7aL34-R34) [[8]](diffhunk://#diff-7fc7ebbe9b146a16ffbb3999cead259e26f555d205235985f66111b4ace24ee2L35-R35) [[9]](diffhunk://#diff-473b40fccf92accd96d5998f35256af1930b27b7b4fe4b0347842291042be713L41-R41)

**Dependency and Project File Updates:**

- Upgraded multiple NuGet package references (such as `Azure.Core`, `Microsoft.Identity.Client`, `Newtonsoft.Json`, and various `System.*` libraries) to newer versions in the project file `OkonkwoOandaV20.csproj` to ensure compatibility and receive the latest fixes and features. [[1]](diffhunk://#diff-f58d17569c292036d34f61c61ed538ba6c32bf57cb3d2aacdc740a1a39f08de6L36-R110) [[2]](diffhunk://#diff-f58d17569c292036d34f61c61ed538ba6c32bf57cb3d2aacdc740a1a39f08de6L118-R139)
- Updated the reference and import of `System.ValueTuple` to version 4.6.2 in the project file.

**File and Compile Item Renaming:**

- Renamed the source file and its references from `ApiParameters.cs` to `ClientParameters.cs` to reflect the new class naming convention.

**Code Cleanup:**

- Removed the unused `GetAzureCredential` method from `Utilities.cs`, as it is no longer necessary or relevant to the current codebase.